### PR TITLE
Fix the leak of buffer for HEIF encoding

### DIFF
--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -1,12 +1,12 @@
 PODS:
-  - SDWebImage/Core (5.0.0-beta3)
-  - SDWebImageHEIFCoder/libde265 (0.2.1):
-    - SDWebImage/Core (>= 5.0.0-beta3)
+  - SDWebImage/Core (5.0.0-beta4)
+  - SDWebImageHEIFCoder/libde265 (0.2.3):
+    - SDWebImage/Core (>= 5.0.0-beta4)
     - SDWebImageHEIFCoder/libheif
-  - SDWebImageHEIFCoder/libheif (0.2.1):
-    - SDWebImage/Core (>= 5.0.0-beta3)
-  - SDWebImageHEIFCoder/libx265 (0.2.1):
-    - SDWebImage/Core (>= 5.0.0-beta3)
+  - SDWebImageHEIFCoder/libheif (0.2.3):
+    - SDWebImage/Core (>= 5.0.0-beta4)
+  - SDWebImageHEIFCoder/libx265 (0.2.3):
+    - SDWebImage/Core (>= 5.0.0-beta4)
     - SDWebImageHEIFCoder/libheif
 
 DEPENDENCIES:
@@ -22,8 +22,8 @@ EXTERNAL SOURCES:
     :path: "../"
 
 SPEC CHECKSUMS:
-  SDWebImage: e52654ceef9fdc19f4c612d64a5b6d3f05dd81a4
-  SDWebImageHEIFCoder: 61950273be2fdecd2097480a17357b75046c0dd7
+  SDWebImage: 56bfe1114b11f1d5766d6d0e3b3456cfd7e1e8b7
+  SDWebImageHEIFCoder: e632735ef0720743f80558a3eb3520b096279f9a
 
 PODFILE CHECKSUM: 81286dae2d6687e2636b6da7a2f711402137c2f9
 

--- a/SDWebImageHEIFCoder/Classes/SDImageHEIFCoder.m
+++ b/SDWebImageHEIFCoder/Classes/SDImageHEIFCoder.m
@@ -23,10 +23,6 @@ typedef enum heif_chroma heif_chroma;
 typedef enum heif_channel heif_channel;
 typedef enum heif_colorspace heif_colorspace;
 
-static void FreeImageData(void *info, const void *data, size_t size) {
-    free((void *)data);
-}
-
 static heif_error WriteImageData(heif_context * ctx, const void * data, size_t size, void * userdata) {
     NSMutableData *imageData = (__bridge NSMutableData *)userdata;
     NSCParameterAssert(imageData);
@@ -84,6 +80,7 @@ static heif_error WriteImageData(heif_context * ctx, const void * data, size_t s
 #else
     UIImage *image = [[UIImage alloc] initWithCGImage:imageRef scale:scale orientation:UIImageOrientationUp];
 #endif
+    CGImageRelease(imageRef);
     
     return image;
 }
@@ -140,7 +137,7 @@ static heif_error WriteImageData(heif_context * ctx, const void * data, size_t s
         return nil;
     }
     CGDataProviderRef provider =
-    CGDataProviderCreateWithData(NULL, rgba, stride * height, FreeImageData);
+    CGDataProviderCreateWithData(NULL, rgba, stride * height, NULL);
     
     CGColorSpaceRef colorSpaceRef = [SDImageCoderHelper colorSpaceGetDeviceRGB];
     CGColorRenderingIntent renderingIntent = kCGRenderingIntentDefault;
@@ -267,12 +264,14 @@ static heif_error WriteImageData(heif_context * ctx, const void * data, size_t s
     };
     if (!dest.data) {
         free(src.data);
+        vImageConverter_Release(convertor);
         heif_context_free(ctx);
         return nil;
     }
     
     // Convert input color mode to RGB888/RGBA8888
     v_error = vImageConvert_AnyToAny(convertor, &src, &dest, NULL, kvImageNoFlags);
+    vImageConverter_Release(convertor);
     if (v_error != kvImageNoError) {
         free(src.data);
         free(dest.data);

--- a/SDWebImageHEIFCoder/Classes/SDImageHEIFCoder.m
+++ b/SDWebImageHEIFCoder/Classes/SDImageHEIFCoder.m
@@ -280,6 +280,7 @@ static heif_error WriteImageData(heif_context * ctx, const void * data, size_t s
         return nil;
     }
     
+    free(src.data);
     void * rgba = dest.data; // Converted buffer
     
     // code to fill in the image


### PR DESCRIPTION
After running the Instruments. I found some leaks from HEIF encoding. So we should fix it.

The following code cause leak:

+ `CGImageRef` does not release
+ `vImageConvert` does not release
+ `src bitmap buffer` does not release.

However, after solve all of them. I found the fact that x265 library itself, contains leakage. No any good idea to fix, until we upgrade the dependency version later.