### PR TITLE
Fix the bug that `heif_image_release` will release the bitmap buffer before CGImage dealloc and cause crash

### DIFF
--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -29,15 +29,15 @@ PODS:
     - libx265/encoder
     - libx265/input
     - libx265/output
-  - SDWebImage/Core (5.0.1)
-  - SDWebImageHEIFCoder/libde265 (0.5.1):
+  - SDWebImage/Core (5.0.4)
+  - SDWebImageHEIFCoder/libde265 (0.5.2):
     - libheif/libde265
     - SDWebImage/Core (~> 5.0)
     - SDWebImageHEIFCoder/libheif
-  - SDWebImageHEIFCoder/libheif (0.5.1):
+  - SDWebImageHEIFCoder/libheif (0.5.2):
     - libheif/libheif (>= 1.4.0)
     - SDWebImage/Core (~> 5.0)
-  - SDWebImageHEIFCoder/libx265 (0.5.1):
+  - SDWebImageHEIFCoder/libx265 (0.5.2):
     - libheif/libx265
     - SDWebImage/Core (~> 5.0)
     - SDWebImageHEIFCoder/libheif
@@ -61,9 +61,9 @@ SPEC CHECKSUMS:
   libde265: b2a0cc3d2aeaafb792b43fcf2a122f42e1de107c
   libheif: e79ed1935019556d3b7a5b8926dcbaa478cb4180
   libx265: 23ab716aae3eff1e6b68b3db6ace8883867691c4
-  SDWebImage: 27dd2c9ea07a2252f94557c9fbb6105ee94b74c9
-  SDWebImageHEIFCoder: 8e078eff3c4dab7d4031331a225948aab396bfa7
+  SDWebImage: c739016e4bdf0a4a1f9a04b5e0385395ad63a282
+  SDWebImageHEIFCoder: f202cd904b30069bccce2bc2ef770d537ffafcc1
 
 PODFILE CHECKSUM: ed097a0e3cb0df40f8e18e8e1e8b396ec38d29ff
 
-COCOAPODS: 1.6.1
+COCOAPODS: 1.7.1

--- a/Example/SDWebImageHEIFCoder.xcodeproj/project.pbxproj
+++ b/Example/SDWebImageHEIFCoder.xcodeproj/project.pbxproj
@@ -391,8 +391,6 @@
 			buildActionMask = 2147483647;
 			files = (
 			);
-			inputFileListPaths = (
-			);
 			inputPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-SDWebImageHEIFCoder_Example macOS/Pods-SDWebImageHEIFCoder_Example macOS-frameworks.sh",
 				"${BUILT_PRODUCTS_DIR}/SDWebImage-macOS/SDWebImage.framework",
@@ -402,8 +400,6 @@
 				"${BUILT_PRODUCTS_DIR}/libx265-macOS/libx265.framework",
 			);
 			name = "[CP] Embed Pods Frameworks";
-			outputFileListPaths = (
-			);
 			outputPaths = (
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/SDWebImage.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/SDWebImageHEIFCoder.framework",
@@ -483,8 +479,6 @@
 			buildActionMask = 2147483647;
 			files = (
 			);
-			inputFileListPaths = (
-			);
 			inputPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-SDWebImageHEIFCoder_Example/Pods-SDWebImageHEIFCoder_Example-frameworks.sh",
 				"${BUILT_PRODUCTS_DIR}/SDWebImage-iOS/SDWebImage.framework",
@@ -494,8 +488,6 @@
 				"${BUILT_PRODUCTS_DIR}/libx265-iOS/libx265.framework",
 			);
 			name = "[CP] Embed Pods Frameworks";
-			outputFileListPaths = (
-			);
 			outputPaths = (
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/SDWebImage.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/SDWebImageHEIFCoder.framework",

--- a/SDWebImageHEIFCoder/Classes/SDImageHEIFCoder.m
+++ b/SDWebImageHEIFCoder/Classes/SDImageHEIFCoder.m
@@ -38,6 +38,11 @@ static heif_error WriteImageData(heif_context * ctx, const void * data, size_t s
     return error;
 }
 
+static void FreeImageData(void *info, const void *data, size_t size) {
+    heif_image *img = (heif_image *)info;
+    heif_image_release(img); // `heif_image_release` will free the bitmap buffer. We do not call `free`
+}
+
 @implementation SDImageHEIFCoder
 
 + (instancetype)sharedCoder {
@@ -152,7 +157,7 @@ static heif_error WriteImageData(heif_context * ctx, const void * data, size_t s
         return nil;
     }
     CGDataProviderRef provider =
-    CGDataProviderCreateWithData(NULL, rgba, stride * height, NULL);
+    CGDataProviderCreateWithData(img, rgba, stride * height, FreeImageData);
     
     CGColorSpaceRef colorSpaceRef = [SDImageCoderHelper colorSpaceGetDeviceRGB];
     CGColorRenderingIntent renderingIntent = kCGRenderingIntentDefault;
@@ -160,7 +165,6 @@ static heif_error WriteImageData(heif_context * ctx, const void * data, size_t s
     
     // clean up
     CGDataProviderRelease(provider);
-    heif_image_release(img);
     heif_image_handle_release(handle);
     heif_context_free(ctx);
     


### PR DESCRIPTION
See #11 

This only happened on real iPhone device but not simulator.

This is because of the wrong implementation of #10 .

`heif_image_release`, will do a `free` call to the bitmap buffer. At that time I only test the iPhone Simulator, but not real device. So I found it's OK.

However, the better solution, it's to use the `CGDataProviderCreateWithData` the `info` arg. We need to pass the `heif_image` opaque pointer, and then using the API to release the bitmap buffer. So this always correct.