### PR TITLE
Performance remove the bitmap copy during encoding

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,6 +185,9 @@ let image = SDImageHEIFCoder.shared.decodedImage(with: data, options: [.decodeTh
 ```objectivec
 UIImage *image;
 NSData *imageData = [image sd_imageDataAsFormat:SDImageFormatHEIF];
+// Encode Quality
+NSData *lossyData = [[SDImageHEIFCoder sharedCoder] encodedDataWithImage:image format:SDImageFormatHEIF options:@{SDImageCoderEncodeCompressionQuality : @(0.1)}]; // [0, 1] compression quality
+NSData *limitedData = [[SDImageHEIFCoder sharedCoder] encodedDataWithImage:image format:SDImageFormatHEIF options:@{SDImageCoderEncodeMaxFileSize : @(1024 * 10)}]; // v0.8.0 feature, limit output file size <= 10KB
 ```
 
 + Swift
@@ -192,7 +195,30 @@ NSData *imageData = [image sd_imageDataAsFormat:SDImageFormatHEIF];
 ```swift
 let image;
 let imageData = image.sd_imageData(as: .HEIF)
+// Encode Quality
+let lossyData = SDImageHEIFCoder.shared.encodedData(with: image, format: .heif, options: [.encodeCompressionQuality: 0.1]) // [0, 1] compression quality
+let limitedData = SDImageHEIFCoder.shared.encodedData(with: image, format: .heif, options: [.encodeMaxFileSize: 1024 * 10]) // v0.8.0 feature, limit output file size <= 10KB
 ```
+
+### Thumbnail Encoding
+
++ Objective-C
+
+```objective-c
+// HEIF image thumbnail encoding
+UIImage *image;
+NSData *thumbnailData = [[SDImageHEIFCoder sharedCoder] encodedDataWithImage:image format:SDImageFormatHEIF options:@{SDImageCoderEncodeMaxPixelSize : @(CGSizeMake(200, 200)}]; // v0.8.0 feature, encoding max pixel size
+```
+
++ Swift
+
+```swift
+// HEIF image thumbnail encoding
+let image: UIImage
+let thumbnailData = SDImageHEIFCoder.shared.encodedData(with: image, format: .heif, options: [.encodeMaxPixelSize: CGSize(width: 200, height: 200)]) // v0.8.0 feature, encoding max pixel size
+```
+
+See more documentation in [SDWebImage Wiki - Coders](https://github.com/SDWebImage/SDWebImage/wiki/Advanced-Usage#custom-coder-420)
 
 ## Screenshot
 

--- a/SDWebImageHEIFCoder/Classes/SDImageHEIFCoder.m
+++ b/SDWebImageHEIFCoder/Classes/SDImageHEIFCoder.m
@@ -451,13 +451,7 @@ static CGSize SDCalculateThumbnailSize(CGSize fullSize, BOOL preserveAspectRatio
     // fill the plane
     int stride;
     uint8_t *planar = heif_image_get_plane(img, channel, &stride);
-    size_t bytes_per_pixel = (bitsPerPixel + 7) / 8;
-    for (int y = 0 ; y < height ; y++) {
-        memcpy(planar + y * stride, rgba + y * stride, width * bytes_per_pixel);
-    }
-    
-    // free the rgba buffer
-    free(rgba);
+    planar = rgba;
     
     // check thumbnail encoding
     int ctuSize = 64;
@@ -469,6 +463,7 @@ static CGSize SDCalculateThumbnailSize(CGSize fullSize, BOOL preserveAspectRatio
         heif_image *thumbnail_img;
         error = heif_image_scale_image(img, &thumbnail_img, (int)scaledSize.width, (int)scaledSize.height, NULL);
         if (error.code != heif_error_Ok) {
+            free(rgba);
             heif_image_release(img);
             heif_encoder_release(encoder);
             heif_context_free(ctx);
@@ -482,6 +477,7 @@ static CGSize SDCalculateThumbnailSize(CGSize fullSize, BOOL preserveAspectRatio
     heif_image_handle *handle;
     error = heif_context_encode_image(ctx, img, encoder, NULL, &handle);
     if (error.code != heif_error_Ok) {
+        free(rgba);
         heif_image_release(img);
         heif_encoder_release(encoder);
         heif_context_free(ctx);
@@ -499,6 +495,7 @@ static CGSize SDCalculateThumbnailSize(CGSize fullSize, BOOL preserveAspectRatio
     error = heif_context_write(ctx, &writer, (__bridge void *)(mutableData));
     
     // clean up
+    free(rgba);
     heif_image_release(img);
     heif_encoder_release(encoder);
     heif_image_handle_release(handle);


### PR DESCRIPTION
The `rgba` bitmap buffer should not be copied, it's useless.